### PR TITLE
Fix link-option order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: _data/London hl-csa-raptor.o
 	./hl-csa-raptor.o -nq=5 $<
 
 %.o: src/%.cc $(HDRS)
-	g++ -std=c++11 -O3 -pthread $(LIBS) -o $@ $<
+	g++ -std=c++11 -O3 -pthread -o $@ $< $(LIBS)
 
 
 REPO:=https://files.inria.fr/gang/graphs/public_transport


### PR DESCRIPTION
On recent gcc version, `--as-needed` seems to be used by default.
This PR thus ensures that `-lz` appears **after** its dependee.